### PR TITLE
Allow SQS connection factory to accept an SQS client

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSConnectionFactory.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSConnectionFactory.java
@@ -187,6 +187,11 @@ public class SQSConnectionFactory implements ConnectionFactory, QueueConnectionF
             setNumberOfMessagesToPrefetch(numberOfMessagesToPrefetch);
             return this;
         }
+        
+        public Builder withSqsClient(AmazonSQS sqsClient) {
+            setSqsClient(sqsClient);
+            return this;
+        }
 
         public SQSConnectionFactory build() {
             return new SQSConnectionFactory(this);


### PR DESCRIPTION
The use case that I want supported is to use the extended client described here: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/s3-messages.html
Since the `AmazonSQSMessagingClientWrapper`can accept an `AmazonSQS` it would be nice if we could pass in an `AmazonSQSExtendedClient` which allows support for storing large messages in S3. This patch allows passing in the extended client through the `SQSConnectionFactory.Builder`
