### PR TITLE
Incorrect requirements for Java and incorrect dependency version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ for communicating with Amazon Simple Queue Service. This project builds on top o
 
 * **Sign up for AWS** — Before you begin, you need an AWS account. For more information about creating an AWS account and retrieving your AWS credentials, see [AWS Account and Credentials](http://docs.aws.amazon.com/AWSSdkDocsJava/latest/DeveloperGuide/java-dg-setup.html) in the AWS SDK for Java Developer Guide.
 * **Sign up for Amazon SQS** — Go to the Amazon [SQS console](https://console.aws.amazon.com/sqs/home?region=us-east-1) to sign up for the service.
-* **Minimum requirements** — To use the sample application, you'll need Java 1.7+ and [Maven 3](http://maven.apache.org/). For more information about the requirements, see the [Getting Started](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/jmsclient.html) section of the Amazon SQS Developer Guide.
+* **Minimum requirements** — To use the sample application, you'll need Java 7 (or later) and [Maven 3](http://maven.apache.org/). For more information about the requirements, see the [Getting Started](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/jmsclient.html) section of the Amazon SQS Developer Guide.
 * **Download** — Download the [latest preview release](https://github.com/awslabs/amazon-sqs-java-messaging-lib/releases) or pick it up from Maven:
 ```xml
   <dependency>
     <groupId>com.amazonaws</groupId>
     <artifactId>amazon-sqs-java-messaging-lib</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <type>jar</type>
   </dependency>
 ```


### PR DESCRIPTION
Currently, Java 7 is required. In addition, the <version> specified within the <dependency> should be 1.0.1. Background:

tharakd@: "Regarding your concern whether the library compiles with Java 6 or not, I was able to dig up some TT which has the following information and validates my suspicion that the code wont compile with Java 6."