### PR TITLE
SQSMessage: do not parse ReceiveCount attribute if it is not set

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
@@ -113,9 +113,10 @@ public class SQSMessage implements Message {
         sqsMessageID = sqsMessage.getMessageId();
         this.messageID = String.format(MESSAGE_ID_FORMAT,sqsMessageID);
         Map<String,String> systemAttributes = sqsMessage.getAttributes();
-        int receiveCount = Integer.parseInt(systemAttributes.get(APPROXIMATE_RECEIVE_COUNT));
+        String receiveCountAttrib = systemAttributes.get(APPROXIMATE_RECEIVE_COUNT);
+        int receiveCount = receiveCountAttrib == null ? 0 : Integer.parseInt(receiveCountAttrib);
         
-        /**
+        /*
          * JMSXDeliveryCount is set based on SQS ApproximateReceiveCount
          * attribute.
          */

--- a/src/test/java/com/amazon/sqs/javamessaging/message/SQSTextMessageTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/message/SQSTextMessageTest.java
@@ -16,9 +16,11 @@ package com.amazon.sqs.javamessaging.message;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
 
 import javax.jms.JMSException;
 
+import com.amazon.sqs.javamessaging.acknowledge.Acknowledger;
 import org.junit.Test;
 
 import com.amazon.sqs.javamessaging.message.SQSTextMessage;
@@ -48,6 +50,22 @@ public class SQSTextMessageTest {
         String actualPayload = sqsTextMessage.getText();
         assertEquals(expectedPayload, actualPayload);
     }
+
+    /**
+     * Test create message from SQS Message
+     */
+    @Test
+    public void testCreateMessageFromSQSMessage() throws JMSException {
+        String messageBody = "theBody";
+        com.amazonaws.services.sqs.model.Message message =
+                new com.amazonaws.services.sqs.model.Message().withBody(messageBody);
+        Acknowledger acknowledger = mock(Acknowledger.class);
+
+        SQSTextMessage sqsTextMessage = new SQSTextMessage(acknowledger, "theQueueUrl", message);
+
+        assertEquals(messageBody, sqsTextMessage.getText());
+    }
+
 
     /**
      * Test create message and setting text


### PR DESCRIPTION
Currently SQSMessage constructor will try to Integer.parse said attribute even if it is not present in source message.

Since you're able to construct model messages without setting that APPROXIMATE_RECEIVE_COUNT attribute, constructor of SQSMessage should handle such objects.