### PR TITLE
Add a default ConnectionFactory constructor

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSConnectionFactory.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSConnectionFactory.java
@@ -62,6 +62,14 @@ public class SQSConnectionFactory implements ConnectionFactory, QueueConnectionF
     }
 
     /*
+     * Creates a default SQSConnectionFactory with a default providerConfiguration
+     */
+    
+    public SQSConnectionFactory() {
+        this(new ProviderConfiguration());
+    }
+    
+    /*
      * Creates a SQSConnectionFactory that uses AmazonSQSClientBuilder.standard() for creating AmazonSQS client connections.
      * Every SQSConnection will have its own copy of AmazonSQS client.
      */


### PR DESCRIPTION
This is needed when there is no ability to change the code of an existing app, only to provide a factory class. Such apps cannot currently load the connector, because they call the default init method which doesn't exist.

the particular culprit is a healthcare processor called mirth connect (http://www.mirthproject.org/) , but I am sure this scenario could just as well apply to other products...