### PR TITLE
Allow consumer to stop processing messages upon closing

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
@@ -570,9 +570,14 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
     }
     
     private boolean cannotDeliver() throws JMSException {
-        if (isClosed() || !running) {
-            return true;
+        if (!running) {
+          return true;
         }
+
+        if (isClosed()) {
+          throw new JMSException("Cannot receive messages when the consumer is closed");
+        }
+
         if (messageListener != null) {
             throw new JMSException("Cannot receive messages synchronously after a message listener is set");
         }


### PR DESCRIPTION
Based on issue https://github.com/awslabs/amazon-sqs-java-messaging-lib/issues/10 this patch updates the `SQSMessageConsumerPrefetch` to throw an exception when the consumer is closed rather than returning `null`. This allows for the `AsyncMessageListenerInvoker` in Spring JMS to stop requesting the consumer receive messages when the `SQSMessageConsumer` has been closed.