### PR TITLE
Support Number and Binary SQS data types listed in the AWS documentation

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
@@ -31,6 +31,12 @@ public class SQSMessagingClientConstants {
     public static final int MIN_PREFETCH = 0;
 
     /**
+     * SQS Message Attribute data type.
+     * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html
+     */
+    public static final String NUMBER = "Number";
+    
+    /**
      * JMSMessage available user property types, which are mapped to message
      * attribute data types
      */

--- a/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
@@ -159,8 +159,7 @@ public class SQSMessage implements Message {
 
     private void addMessageAttributes(com.amazonaws.services.sqs.model.Message sqsMessage) throws JMSException {
         for (Entry<String, MessageAttributeValue> entry : sqsMessage.getMessageAttributes().entrySet()) {
-            properties.put(entry.getKey(), new JMSMessagePropertyValue(
-                    entry.getValue().getStringValue(), entry.getValue().getDataType()));
+        	properties.put(entry.getKey(), new JMSMessagePropertyValue(entry.getValue().getStringValue(), entry.getValue().getDataType()));
         }
     }
 
@@ -1210,6 +1209,9 @@ public class SQSMessage implements Message {
                 return Float.valueOf(value);
             } else if (SHORT.equals(type)) {
                 return Short.valueOf(value);
+            } else if (NUMBER.equals(type)) {
+            	// This may not be a JMS Type but it is a SQS Type, so we had better support it.
+            	return value;
             } else {
                 throw new JMSException(type + " is not a supported JMS property type");
             }

--- a/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
@@ -28,14 +28,14 @@ import com.amazon.sqs.javamessaging.SQSSession;
 import com.amazon.sqs.javamessaging.acknowledge.Acknowledger;
 import com.amazon.sqs.javamessaging.message.SQSMessage;
 import com.amazonaws.services.sqs.model.MessageAttributeValue;
+
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.jms.Message;
 import javax.jms.MessageFormatException;
 import javax.jms.MessageNotWriteableException;
-
-import junit.framework.Assert;
 
 import java.util.*;
 
@@ -44,6 +44,8 @@ import java.util.*;
  */
 public class SQSMessageTest {
     private SQSSession mockSQSSession;
+    final String myNumber = "myNumber";
+    final String myNumberOverflow = "myNumberOverflow";
     final String myTrueBoolean = "myTrueBoolean";
     final String myFalseBoolean = "myFalseBoolean";
     final String myInteger = "myInteger";
@@ -67,65 +69,66 @@ public class SQSMessageTest {
         when(mockSQSSession.createMessage()).thenReturn(new SQSMessage());
         Message message = mockSQSSession.createMessage();
 
-        message.setBooleanProperty("myTrueBoolean", true);
-        message.setBooleanProperty("myFalseBoolean", false);
-        message.setIntProperty("myInteger", 100);
-        message.setDoubleProperty("myDouble", 2.1768);
-        message.setFloatProperty("myFloat", 3.1457f);
-        message.setLongProperty("myLong", 1290772974281L);
-        message.setShortProperty("myShort", (short) 123);
-        message.setByteProperty("myByteProperty", (byte) 'a');
-        message.setStringProperty("myString", "StringValue");
+        message.setBooleanProperty(myTrueBoolean, true);
+        message.setBooleanProperty(myFalseBoolean, false);
+        message.setIntProperty(myInteger, 100);
+        message.setDoubleProperty(myDouble, 2.1768);
+        message.setFloatProperty(myFloat, 3.1457f);
+        message.setLongProperty(myLong, 1290772974281L);
+        message.setShortProperty(myShort, (short) 123);
+        message.setByteProperty(myByte, (byte) 'a');
+        message.setStringProperty(myString, "StringValue");
 
-        Assert.assertTrue(message.propertyExists("myTrueBoolean"));
-        Assert.assertEquals(message.getObjectProperty("myTrueBoolean"), true);
-        Assert.assertEquals(message.getBooleanProperty("myTrueBoolean"), true);
+        Assert.assertTrue(message.propertyExists(myTrueBoolean));
+        Assert.assertEquals(message.getObjectProperty(myTrueBoolean), true);
+        Assert.assertEquals(message.getBooleanProperty(myTrueBoolean), true);
         
-        Assert.assertTrue(message.propertyExists("myFalseBoolean"));
-        Assert.assertEquals(message.getObjectProperty("myFalseBoolean"), false);
-        Assert.assertEquals(message.getBooleanProperty("myFalseBoolean"), false);
+        Assert.assertTrue(message.propertyExists(myFalseBoolean));
+        Assert.assertEquals(message.getObjectProperty(myFalseBoolean), false);
+        Assert.assertEquals(message.getBooleanProperty(myFalseBoolean), false);
         
-        Assert.assertTrue(message.propertyExists("myInteger"));
-        Assert.assertEquals(message.getObjectProperty("myInteger"), 100);
-        Assert.assertEquals(message.getIntProperty("myInteger"), 100);
+        Assert.assertTrue(message.propertyExists(myInteger));
+        Assert.assertEquals(message.getObjectProperty(myInteger), 100);
+        Assert.assertEquals(message.getIntProperty(myInteger), 100);
         
-        Assert.assertTrue(message.propertyExists("myDouble"));
-        Assert.assertEquals(message.getObjectProperty("myDouble"), 2.1768);
-        Assert.assertEquals(message.getDoubleProperty("myDouble"), 2.1768);
+        Assert.assertTrue(message.propertyExists(myDouble));
+        Assert.assertEquals((double)message.getObjectProperty(myDouble), 2.1768, 0);
+        Assert.assertEquals(message.getDoubleProperty(myDouble), 2.1768, 0);
         
-        Assert.assertTrue(message.propertyExists("myFloat"));
-        Assert.assertEquals(message.getObjectProperty("myFloat"), 3.1457f);
-        Assert.assertEquals(message.getFloatProperty("myFloat"), 3.1457f);
+        Assert.assertTrue(message.propertyExists(myFloat));
+        Assert.assertEquals((float)message.getObjectProperty(myFloat), 3.1457f, 0);
+        Assert.assertEquals(message.getFloatProperty(myFloat), 3.1457f, 0);
         
-        Assert.assertTrue(message.propertyExists("myLong"));
-        Assert.assertEquals(message.getObjectProperty("myLong"), 1290772974281L);
-        Assert.assertEquals(message.getLongProperty("myLong"), 1290772974281L);
+        Assert.assertTrue(message.propertyExists(myLong));
+        Assert.assertEquals(message.getObjectProperty(myLong), 1290772974281L);
+        Assert.assertEquals(message.getLongProperty(myLong), 1290772974281L);
         
-        Assert.assertTrue(message.propertyExists("myShort"));
-        Assert.assertEquals(message.getObjectProperty("myShort"), (short) 123);
-        Assert.assertEquals(message.getShortProperty("myShort"), (short) 123);
+        Assert.assertTrue(message.propertyExists(myShort));
+        Assert.assertEquals(message.getObjectProperty(myShort), (short) 123);
+        Assert.assertEquals(message.getShortProperty(myShort), (short) 123);
         
-        Assert.assertTrue(message.propertyExists("myByteProperty"));
-        Assert.assertEquals(message.getObjectProperty("myByteProperty"), (byte) 'a');
-        Assert.assertEquals(message.getByteProperty("myByteProperty"), (byte) 'a');
+        Assert.assertTrue(message.propertyExists(myByte));
+        Assert.assertEquals(message.getObjectProperty(myByte), (byte) 'a');
+        Assert.assertEquals(message.getByteProperty(myByte), (byte) 'a');
         
-        Assert.assertTrue(message.propertyExists("myString"));
-        Assert.assertEquals(message.getObjectProperty("myString"), "StringValue");
-        Assert.assertEquals(message.getStringProperty("myString"), "StringValue");
+        Assert.assertTrue(message.propertyExists(myString));
+        Assert.assertEquals(message.getObjectProperty(myString), "StringValue");
+        Assert.assertEquals(message.getStringProperty(myString), "StringValue");
 
         // Validate property names
         Set<String> propertyNamesSet = new HashSet<String>(Arrays.asList(
-                "myTrueBoolean",
-                "myFalseBoolean",
-                "myInteger",
-                "myDouble",
-                "myFloat",
-                "myLong",
-                "myShort",
-                "myByteProperty",
-                "myString"));
+                myTrueBoolean,
+                myFalseBoolean,
+                myInteger,
+                myDouble,
+                myFloat,
+                myLong,
+                myShort,
+                myByte,
+                myString));
 
-        Enumeration<String > propertyNames = message.getPropertyNames();
+        @SuppressWarnings("unchecked")
+		Enumeration<String> propertyNames = message.getPropertyNames();
         int counter = 0;
         while (propertyNames.hasMoreElements()) {
             assertTrue(propertyNamesSet.contains(propertyNames.nextElement()));
@@ -134,15 +137,10 @@ public class SQSMessageTest {
         assertEquals(propertyNamesSet.size(), counter);
         
         message.clearProperties();
-        Assert.assertFalse(message.propertyExists("myTrueBoolean"));
-        Assert.assertFalse(message.propertyExists("myInteger"));
-        Assert.assertFalse(message.propertyExists("myDouble"));
-        Assert.assertFalse(message.propertyExists("myFloat"));
-        Assert.assertFalse(message.propertyExists("myLong"));
-        Assert.assertFalse(message.propertyExists("myShort"));
-        Assert.assertFalse(message.propertyExists("myByteProperty"));
-        Assert.assertFalse(message.propertyExists("myString"));
-
+        for (String propName: propertyNamesSet) {
+        	Assert.assertFalse(message.propertyExists(propName));
+        }
+        
         propertyNames = message.getPropertyNames();
         assertFalse(propertyNames.hasMoreElements());
     }
@@ -272,11 +270,23 @@ public class SQSMessageTest {
 
         Acknowledger ack = mock(Acknowledger.class);
 
+        // 52 digits of value.
+        final String numberOverflowValue = "1234567890123456789012345678901234567890123456789012";
+        
         Map<String,String> systemAttributes = new HashMap<String, String>();
         systemAttributes.put(APPROXIMATE_RECEIVE_COUNT, "100");
 
         Map<String, MessageAttributeValue> messageAttributes = new HashMap<String, MessageAttributeValue>();
 
+        /* SQS Supports Logical Data Types: String, Number, and Binary so we'd best know what to do with those at the very minimum! */
+        messageAttributes.put(myNumber, new MessageAttributeValue()
+        		.withDataType(SQSMessagingClientConstants.NUMBER)
+        		.withStringValue("4"));
+        
+        messageAttributes.put(myNumberOverflow, new MessageAttributeValue()
+        		.withDataType(SQSMessagingClientConstants.NUMBER)
+        		.withStringValue(numberOverflowValue));
+        
         messageAttributes.put(myTrueBoolean, new MessageAttributeValue()
                                                     .withDataType(SQSMessagingClientConstants.BOOLEAN)
                                                     .withStringValue("1"));
@@ -312,6 +322,7 @@ public class SQSMessageTest {
         messageAttributes.put(myString, new MessageAttributeValue()
                                                     .withDataType(SQSMessagingClientConstants.STRING)
                                                     .withStringValue("StringValue"));
+        
 
         com.amazonaws.services.sqs.model.Message sqsMessage = new com.amazonaws.services.sqs.model.Message()
                 .withMessageAttributes(messageAttributes)
@@ -321,6 +332,27 @@ public class SQSMessageTest {
 
         SQSMessage message = new SQSMessage(ack, "QueueUrl", sqsMessage);
 
+        // SQS "Number" data type must use StringValue, may be a floating point number
+        Assert.assertTrue(message.propertyExists(myNumber));
+        Assert.assertEquals("4", message.getObjectProperty(myNumber));
+        Assert.assertEquals("4", message.getStringProperty(myNumber));
+        Assert.assertEquals(4, message.getIntProperty(myNumber));
+        Assert.assertEquals(4.0, message.getDoubleProperty(myNumber), 0);
+        
+        // A Number can hold a value with quite a lot of significant digits, it must be represented as a StringValue,
+        // and can be interpreted as other things, but we should expect errors if the value overflows.
+        Assert.assertTrue(message.propertyExists(myNumberOverflow));
+        Assert.assertEquals(numberOverflowValue, message.getObjectProperty(myNumberOverflow));
+        Assert.assertEquals(numberOverflowValue, message.getStringProperty(myNumberOverflow));
+        // Expecting a loss of precision here when interpreted as a double.
+        Assert.assertEquals(1.23456789012345678E51, message.getDoubleProperty(myNumberOverflow), 0);
+        try {
+        	message.getIntProperty(myNumberOverflow);
+        	Assert.fail("message.getIntProperty did not throw a NumberFormatException");
+        } catch (NumberFormatException nfe) {
+        	Assert.assertEquals("For input string: \""+numberOverflowValue+"\"", nfe.getMessage());
+        }
+        
         Assert.assertTrue(message.propertyExists(myTrueBoolean));
         Assert.assertEquals(message.getObjectProperty(myTrueBoolean), true);
         Assert.assertEquals(message.getBooleanProperty(myTrueBoolean), true);
@@ -334,12 +366,12 @@ public class SQSMessageTest {
         Assert.assertEquals(message.getIntProperty(myInteger), 100);
 
         Assert.assertTrue(message.propertyExists(myDouble));
-        Assert.assertEquals(message.getObjectProperty(myDouble), 2.1768);
-        Assert.assertEquals(message.getDoubleProperty(myDouble), 2.1768);
+        Assert.assertEquals((double)message.getObjectProperty(myDouble), 2.1768, 0);
+        Assert.assertEquals(message.getDoubleProperty(myDouble), 2.1768, 0);
 
         Assert.assertTrue(message.propertyExists(myFloat));
-        Assert.assertEquals(message.getObjectProperty(myFloat), 3.1457f);
-        Assert.assertEquals(message.getFloatProperty(myFloat), 3.1457f);
+        Assert.assertEquals((float)message.getObjectProperty(myFloat), 3.1457f, 0);
+        Assert.assertEquals(message.getFloatProperty(myFloat), 3.1457f, 0);
 
         Assert.assertTrue(message.propertyExists(myLong));
         Assert.assertEquals(message.getObjectProperty(myLong), 1290772974281L);
@@ -360,6 +392,8 @@ public class SQSMessageTest {
 
         // Validate property names
         Set<String> propertyNamesSet = new HashSet<String>(Arrays.asList(
+        		myNumber,
+        		myNumberOverflow,
                 myTrueBoolean,
                 myFalseBoolean,
                 myInteger,
@@ -374,7 +408,8 @@ public class SQSMessageTest {
         Enumeration<String > propertyNames = message.getPropertyNames();
         int counter = 0;
         while (propertyNames.hasMoreElements()) {
-            assertTrue(propertyNamesSet.contains(propertyNames.nextElement()));
+        	String propName = propertyNames.nextElement();
+            Assert.assertTrue("Found Unknown Property: " + propName, propertyNamesSet.contains(propName));
             counter++;
         }
         assertEquals(propertyNamesSet.size(), counter);


### PR DESCRIPTION
Documentation on SQS DataType values found at:
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html