### PR TITLE
Support SQS messages with Type Binary and Number

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
@@ -36,6 +36,8 @@ public class SQSMessagingClientConstants {
      */
     public static final String STRING = "String";
 
+    public static final String BINARY = "Binary";
+
     public static final String NUMBER = "Number";
 
     public static final String INT = "Number.int";

--- a/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
@@ -1194,6 +1194,8 @@ public class SQSMessage implements Message {
         private static Object getObjectValue(String value, String type) throws JMSException {
             if (INT.equals(type)) {
                 return Integer.valueOf(value);
+            } else if (STRING.equals(type) || NUMBER.equals(type) || BINARY.equals(type)) {
+                return value;
             } else if (LONG.equals(type)) {
                 return Long.valueOf(value);
             } else if (BOOLEAN.equals(type)) {

--- a/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/message/SQSMessageTest.java
@@ -55,6 +55,7 @@ public class SQSMessageTest {
     final String myString = "myString";
     final String myCustomString = "myCustomString";
     final String myNumber = "myNumber";
+    final String myBinary = "myBinary";
 
     @Before
     public void setup() {
@@ -79,6 +80,7 @@ public class SQSMessageTest {
         message.setByteProperty("myByteProperty", (byte) 'a');
         message.setStringProperty("myString", "StringValue");
         message.setStringProperty("myNumber", "500");
+        message.setStringProperty("myBinary", "binarydata");
 
         Assert.assertTrue(message.propertyExists("myTrueBoolean"));
         Assert.assertEquals(message.getObjectProperty("myTrueBoolean"), true);
@@ -125,6 +127,10 @@ public class SQSMessageTest {
         Assert.assertEquals(message.getDoubleProperty("myNumber"), 500d);
         Assert.assertEquals(message.getIntProperty("myNumber"), 500);
 
+        Assert.assertTrue(message.propertyExists("myBinary"));
+        Assert.assertEquals(message.getObjectProperty("myBinary"), "binarydata");
+        Assert.assertEquals(message.getStringProperty("myBinary"), "binarydata");
+
         // Validate property names
         Set<String> propertyNamesSet = new HashSet<String>(Arrays.asList(
                 "myTrueBoolean",
@@ -136,6 +142,7 @@ public class SQSMessageTest {
                 "myShort",
                 "myByteProperty",
                 "myNumber",
+                "myBinary",
                 "myString"));
 
         Enumeration<String > propertyNames = message.getPropertyNames();
@@ -156,6 +163,7 @@ public class SQSMessageTest {
         Assert.assertFalse(message.propertyExists("myByteProperty"));
         Assert.assertFalse(message.propertyExists("myString"));
         Assert.assertFalse(message.propertyExists("myNumber"));
+        Assert.assertFalse(message.propertyExists("myBinary"));
 
         propertyNames = message.getPropertyNames();
         assertFalse(propertyNames.hasMoreElements());
@@ -335,6 +343,10 @@ public class SQSMessageTest {
                                                     .withDataType(SQSMessagingClientConstants.NUMBER)
                                                     .withStringValue("500"));
 
+        messageAttributes.put(myBinary, new MessageAttributeValue()
+                                                    .withDataType(SQSMessagingClientConstants.BINARY)
+                                                    .withStringValue("binarydata"));
+
         com.amazonaws.services.sqs.model.Message sqsMessage = new com.amazonaws.services.sqs.model.Message()
                 .withMessageAttributes(messageAttributes)
                 .withAttributes(systemAttributes)
@@ -392,6 +404,9 @@ public class SQSMessageTest {
         Assert.assertEquals(message.getFloatProperty(myNumber), 500f);
         Assert.assertEquals(message.getDoubleProperty(myNumber), 500d);
 
+        Assert.assertTrue(message.propertyExists(myBinary));
+        Assert.assertEquals(message.getObjectProperty(myBinary), "binarydata");
+        Assert.assertEquals(message.getStringProperty(myBinary), "binarydata");
 
         // Validate property names
         Set<String> propertyNamesSet = new HashSet<String>(Arrays.asList(
@@ -406,6 +421,7 @@ public class SQSMessageTest {
                 myString,
                 myCustomString,
                 myNumber,
+                myBinary,
                 JMSX_DELIVERY_COUNT));
 
         Enumeration<String > propertyNames = message.getPropertyNames();
@@ -426,6 +442,7 @@ public class SQSMessageTest {
         Assert.assertFalse(message.propertyExists("myByteProperty"));
         Assert.assertFalse(message.propertyExists("myString"));
         Assert.assertFalse(message.propertyExists("myNumber"));
+        Assert.assertFalse(message.propertyExists("myBinary"));
 
         propertyNames = message.getPropertyNames();
         assertFalse(propertyNames.hasMoreElements());


### PR DESCRIPTION
The SQS documentation indicates that messages with "Type" of "Number" and "Binary" are valid, see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html

This PR adds support for these "Type" values. According to https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-attributes.html
> Number – Number attributes can store positive or negative numerical values. A number can have up to 38 digits of precision, and it can be between 10^-128 and 10^+126.

That means that this library cannot internally handle values as the largest JMS allowed numeric type (which is `Double` see https://docs.oracle.com/javaee/6/api/javax/jms/Message.html ) is not big enough to handle such values. Therefore, this PR treats "Number" values internally as strings, converting them upon request when methods such as `Message.getDouble(String)` are invoked.

The same approach is used for "Binary" - the value is held in a `String`.  `ByteBuffer` or `byte[]`, for example, as those are not JMS permitted data types, from https://docs.oracle.com/javaee/6/api/javax/jms/Message.html :
> The getObjectProperty method only returns values of class Boolean, Byte, Short, Integer, Long, Float, Double, and String.

See #60