### PR TITLE
Adding a way to set individual message delay with message property

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
@@ -70,7 +70,8 @@ public class SQSMessage implements Message {
     public static final String JMS_SQS_REPLY_TO_QUEUE_NAME = "JMS_SQSReplyToQueueName";
     public static final String JMS_SQS_REPLY_TO_QUEUE_URL = "JMS_SQSReplyToQueueURL";
     public static final String JMS_SQS_CORRELATION_ID = "JMS_SQSCorrelationID";
-    
+    public static final String SQS_SCHEDULED_DELAY = "SQSScheduledDelay";
+
     // Default JMS Message properties
     private int deliveryMode = Message.DEFAULT_DELIVERY_MODE;
     private int priority = Message.DEFAULT_PRIORITY;


### PR DESCRIPTION
*Description of changes:*
I've added a way to set individual message delays via a message property - `SQSMessage. SQS_SCHEDULED_DELAY`.
This will take priority over the MessageProducer's delay when set.

Let me know what you think 😄 
Stanley

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
