### PR TITLE
Mark MessageListener as ready on prefetch start

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
@@ -548,7 +548,7 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
         }
         synchronized (stateLock) {
             running = true;
-            notifyStateChange();
+            messageListenerReady();
         }
     }
 

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
@@ -1919,6 +1919,22 @@ public class SQSMessageConsumerPrefetchTest {
         consumerPrefetch.run();
     }
 
+    /**
+     * Test SetMessageListener before starting prefetch
+     * Setting MessageListener before starting prefetch would not mark
+     * the message listener as ready. Therefore start() method should
+     * do this work in order to get pre-fetch going even when
+     * number of messages to pre-fetch is set to 0.
+     */
+    @Test
+    public void testSetMessageListenerBeforeStart() {
+
+        MessageListener msgListener = mock(MessageListener.class);
+        consumerPrefetch.setMessageListener(msgListener);
+        consumerPrefetch.start();
+        assertEquals(1, consumerPrefetch.messagesRequested);
+    }
+
     /*
      * Utility functions
      */


### PR DESCRIPTION
Setting MessageListener before starting prefetch would
not mark the message listener as ready. Therefore start()
method should do this work in order to get pre-fetch
going even when number of messages to pre-fetch is set to 0.

Closes #86