### PR TITLE
Update SQSConnection to avoid race condition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.amazonaws</groupId>
   <artifactId>amazon-sqs-java-messaging-lib</artifactId>
-  <version>1.0.8</version>
+  <version>1.0.9</version>
   <packaging>jar</packaging>
   <name>Amazon SQS Java Messaging Library</name>
   <description>The Amazon SQS Java Messaging Library holds the Java Message Service compatible classes, that are used

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSConnection.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSConnection.java
@@ -196,7 +196,14 @@ public class SQSConnection implements Connection, QueueConnection {
             throw new JMSException("Unrecognized acknowledgeMode. Cannot create Session.");
         }
         synchronized (stateLock) { 
-            checkClosing();
+            if (closing) {
+                /**
+                 * SQSSession's constructor has already started a SQSSessionCallbackScheduler which should be closed
+                 * before leaving sqsSession object.
+                 */
+                sqsSession.close();
+                throw new IllegalStateException("Connection is closed or closing");
+            }
             sessions.add(sqsSession);
 
             /**


### PR DESCRIPTION
Fixing a potential bug: SQSSessionCallbackScheduler left threads in waiting state infinitely.

*Issue #, if available: 105

*Description of changes: Fixing a potential bug: SQSSessionCallbackScheduler left threads in waiting state infinitely.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
