### PR TITLE
Improve logging

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumer.java
@@ -224,7 +224,7 @@ public class SQSMessageConsumer implements MessageConsumer, QueueReceiver {
 
         try {
             if (!prefetchExecutor.isShutdown()) {
-                LOG.info("Shutting down " + SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME + " executor");
+                LOG.info("Shutting down {} executor", SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME);
                 // Shut down executor.
                 prefetchExecutor.shutdown();
             }
@@ -233,9 +233,8 @@ public class SQSMessageConsumer implements MessageConsumer, QueueReceiver {
 
             if (!prefetchExecutor.awaitTermination(PREFETCH_EXECUTOR_GRACEFUL_SHUTDOWN_TIME, TimeUnit.SECONDS)) {
 
-                LOG.warn("Can't terminate executor service " + SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME +
-                         " after " + PREFETCH_EXECUTOR_GRACEFUL_SHUTDOWN_TIME +
-                         " seconds, some running threads will be shutdown immediately");
+                LOG.warn("Can't terminate executor service {} after {} seconds, some running threads will be shutdown immediately",
+                        SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME, PREFETCH_EXECUTOR_GRACEFUL_SHUTDOWN_TIME);
                 prefetchExecutor.shutdownNow();
             }
         } catch (InterruptedException e) {

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumer.java
@@ -224,7 +224,7 @@ public class SQSMessageConsumer implements MessageConsumer, QueueReceiver {
 
         try {
             if (!prefetchExecutor.isShutdown()) {
-                LOG.info("Shutting down {} executor", SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME);
+                LOG.debug("Shutting down {} executor", SQSSession.CONSUMER_PREFETCH_EXECUTOR_NAME);
                 // Shut down executor.
                 prefetchExecutor.shutdown();
             }

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
@@ -349,8 +349,7 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
                 try {
                     jmsMessage = new SQSBytesMessage(acknowledger, queueUrl, message);
                 } catch (JMSException e) {
-                    LOG.warn("MessageReceiptHandle - " + message.receiptHandle() +
-                             "cannot be serialized to BytesMessage", e);
+                    LOG.warn("MessageReceiptHandle - {} cannot be serialized to BytesMessage", message.receiptHandle(), e);
                     throw e;
                 }
             } else if (SQSMessage.OBJECT_MESSAGE_TYPE.equals(messageType)) {

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -152,7 +152,7 @@ public class SQSMessageProducer implements MessageProducer, QueueSender {
 
         SendMessageResponse sendMessageResult = amazonSQSClient.sendMessage(sendMessageRequest.build());
         String messageId = sendMessageResult.messageId();
-        LOG.info("Message sent to SQS with SQS-assigned messageId: " + messageId);
+        LOG.info("Message sent to SQS with SQS-assigned messageId: {}", messageId);
         // TODO: Do not support disableMessageID for now.
         message.setSQSMessageId(messageId);
 

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
@@ -152,7 +152,7 @@ public class SQSMessageProducer implements MessageProducer, QueueSender {
 
         SendMessageResponse sendMessageResult = amazonSQSClient.sendMessage(sendMessageRequest.build());
         String messageId = sendMessageResult.messageId();
-        LOG.info("Message sent to SQS with SQS-assigned messageId: {}", messageId);
+        LOG.debug("Message sent to SQS with SQS-assigned messageId: {}", messageId);
         // TODO: Do not support disableMessageID for now.
         message.setSQSMessageId(messageId);
 

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2010-2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -405,7 +405,7 @@ public class SQSSession implements Session, QueueSession {
 
                 try {
                     if (executor != null) {
-                        LOG.info("Shutting down " + SESSION_EXECUTOR_NAME + " executor");
+                        LOG.info("Shutting down {} executor", SESSION_EXECUTOR_NAME);
 
                         executor.shutdown();
 
@@ -419,9 +419,8 @@ public class SQSSession implements Session, QueueSession {
 
                         if (!executor.awaitTermination(10, TimeUnit.SECONDS)) {
 
-                            LOG.warn("Can't terminate executor service " + SESSION_EXECUTOR_NAME + " after " +
-                                    SESSION_EXECUTOR_GRACEFUL_SHUTDOWN_TIME +
-                                    " seconds, some running threads will be shutdown immediately");
+                            LOG.warn("Can't terminate executor service {} after {} seconds, some running threads will be shutdown immediately",
+                                    SESSION_EXECUTOR_NAME, SESSION_EXECUTOR_GRACEFUL_SHUTDOWN_TIME);
                             executor.shutdownNow();
                         }
                     }

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
@@ -405,7 +405,7 @@ public class SQSSession implements Session, QueueSession {
 
                 try {
                     if (executor != null) {
-                        LOG.info("Shutting down {} executor", SESSION_EXECUTOR_NAME);
+                        LOG.debug("Shutting down {} executor", SESSION_EXECUTOR_NAME);
 
                         executor.shutdown();
 

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSSessionCallbackScheduler.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSSessionCallbackScheduler.java
@@ -143,7 +143,7 @@ public class SQSSessionCallbackScheduler implements Runnable {
                                 try {
                                     messageListener.onMessage(message);
                                 } catch (Throwable ex) {
-                                    LOG.info("Exception thrown from onMessage callback for message {}",
+                                    LOG.warn("Exception thrown from onMessage callback for message {}",
                                             message.getSQSMessageId(), ex);
                                     callbackFailed = true;
                                 } finally {

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSSessionCallbackScheduler.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSSessionCallbackScheduler.java
@@ -103,9 +103,7 @@ public class SQSSessionCallbackScheduler implements Runnable {
                                  * Will be retried on the next loop, and
                                  * break if the callback scheduler is closed.
                                  */
-                                if (LOG.isDebugEnabled()) {
-                                    LOG.debug("wait on empty callback queue interrupted: " + e.getMessage());
-                                }
+                                LOG.debug("wait on empty callback queue interrupted: {}", e.getMessage());
                             }
                             continue;
                         }
@@ -124,9 +122,7 @@ public class SQSSessionCallbackScheduler implements Runnable {
                         // this takes care of start and stop
                         session.startingCallback(messageConsumer);
                     } catch (JMSException e) {
-                        if (LOG.isDebugEnabled()) {
-                            LOG.debug("Not running callback: " + e.getMessage());
-                        }
+                        LOG.debug("Not running callback: {}", e.getMessage());
                         break;
                     }
 
@@ -147,8 +143,8 @@ public class SQSSessionCallbackScheduler implements Runnable {
                                 try {
                                     messageListener.onMessage(message);
                                 } catch (Throwable ex) {
-                                    LOG.info("Exception thrown from onMessage callback for message " +
-                                             message.getSQSMessageId(), ex);
+                                    LOG.info("Exception thrown from onMessage callback for message {}",
+                                            message.getSQSMessageId(), ex);
                                     callbackFailed = true;
                                 } finally {
                                     if (!callbackFailed) {
@@ -160,9 +156,8 @@ public class SQSSessionCallbackScheduler implements Runnable {
                                 }
                             }
                         } catch (JMSException ex) {
-                            LOG.warn(
-                                    "Unable to complete message dispatch for the message " +
-                                            message.getSQSMessageId(), ex);
+                            LOG.warn("Unable to complete message dispatch for the message {}",
+                                    message.getSQSMessageId(), ex);
                         } finally {
                             if (tryNack) {
                                 nackReceivedMessage(message);
@@ -248,7 +243,7 @@ public class SQSSessionCallbackScheduler implements Runnable {
             
             negativeAcknowledger.bulkAction(nackMessageIdentifiers, nackMessageIdentifiers.size());
         } catch (JMSException e) {
-            LOG.warn("Unable to nack the message " + message.getSQSMessageId(), e);
+            LOG.warn("Unable to nack the message {}", message.getSQSMessageId(), e);
         }
     }
 

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/RangedAcknowledger.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/RangedAcknowledger.java
@@ -72,8 +72,8 @@ public class RangedAcknowledger extends BulkSQSOperation implements Acknowledger
          * the messages received before that
          */
         if (indexOfMessage == -1) {
-            LOG.warn("SQSMessageID: " + message.getSQSMessageId() + " with SQSMessageReceiptHandle: " +
-                     message.getReceiptHandle() + " does not exist.");
+            LOG.warn("SQSMessageID: {} with SQSMessageReceiptHandle: {} does not exist.", message.getSQSMessageId(),
+                    message.getReceiptHandle());
         } else {
             bulkAction(getUnAckMessages(), indexOfMessage);
         }


### PR DESCRIPTION
This PR contains two commits that improve logging.

---

[Avoid string concatenation in logging statements](https://github.com/awslabs/amazon-sqs-java-messaging-lib/commit/caea19da037320a5ff14c45b141f0fb7ea1ef049)

This commit removes string concatenation in logging statements where
possible, in favor of format-based logging messages.

---

[Tweak logging statement levels](https://github.com/awslabs/amazon-sqs-java-messaging-lib/commit/41aaf19b0eed630fdb04edf5982b3e748d0cfa99)

At present, for every JMS message sent there are the following 2
statements logged at info level:

- messageId in SQSMessageProducer#sendInternal
- shutting down executor in SQSSession#doClose

These result in excessive logging for systems that product a lot of JMS
messages and are really better fit for debug level.

Additionally, SQSMessageConsumer#doClose also has an equivalent logging
statement to one in SQSSession#doClose.

Finally, SQSSessionCallbackScheduler#run contains logging statement that
 logs exception at info level, which is better suited for warn level.