### PR TITLE
Adding null check for error code

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClientWrapper.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClientWrapper.java
@@ -377,7 +377,7 @@ public class AmazonSQSMessagingClientWrapper {
     }
 
     private static String errorCode(AwsServiceException e) {
-        return e.awsErrorDetails() != null ? e.awsErrorDetails().errorCode() : "";
+        return e.awsErrorDetails() != null && e.awsErrorDetails().errorCode() != null ? e.awsErrorDetails().errorCode() : "";
     }
 
 


### PR DESCRIPTION
Fixing null pointer exception which is occurs when error code is null. This cause original exception to be lost.

*Issue #, if available:*

*Description of changes:*
Adding null check for `errorCode`  in the method `errorCode` of `AmazonSQSMessagingClientWrapper`. Method `isJMSSecurityException` checks in the Set 
`SECURITY_EXCEPTION_ERROR_CODES` for presence of error code. Set internally calls Objects.requireNonNull which throws Null pointer exception *Ref: https://github.com/corretto/corretto-17/blob/4806b202a348e6344c84a89ea23eef026788126a/src/java.base/share/classes/java/util/Objects.java#L209*. 

This causes original exception to be lost and it never gets reported.  Below is an example stacktrace where due to proxy auth issue *(Service returned HTTP status code 407 (Service: Sqs, Status Code: 407, Request ID: null))* lib reported null pointer instead of original error:

```
Exception occurred while acknowledging SQS message:null java.lang.NullPointerException
    at java.base/java.util.Objects.requireNonNull(Objects.java:209)
    at java.base/java.util.ImmutableCollections$SetN.contains(ImmutableCollections.java:937)
    at com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper.isJMSSecurityException(AmazonSQSMessagingClientWrapper.java:385)
    at com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper.handleException(AmazonSQSMessagingClientWrapper.java:364)
    at com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper.deleteMessage(AmazonSQSMessagingClientWrapper.java:109)
    at com.amazon.sqs.javamessaging.acknowledge.UnorderedAcknowledger.acknowledge(UnorderedAcknowledger.java:55)
    at com.amazon.sqs.javamessaging.message.SQSMessage.acknowledge(SQSMessage.java:863)
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
