### PR TITLE
Add SQS Async Client support

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/AbstractSQSConnectionFactory.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AbstractSQSConnectionFactory.java
@@ -1,0 +1,29 @@
+package com.amazon.sqs.javamessaging;
+
+import jakarta.jms.ConnectionFactory;
+import jakarta.jms.JMSContext;
+import jakarta.jms.JMSRuntimeException;
+import jakarta.jms.QueueConnectionFactory;
+
+public abstract class AbstractSQSConnectionFactory implements ConnectionFactory, QueueConnectionFactory {
+
+    @Override
+    public JMSContext createContext() {
+        throw new JMSRuntimeException(SQSMessagingClientConstants.UNSUPPORTED_METHOD);
+    }
+
+    @Override
+    public JMSContext createContext(String userName, String password) {
+        throw new JMSRuntimeException(SQSMessagingClientConstants.UNSUPPORTED_METHOD);
+    }
+
+    @Override
+    public JMSContext createContext(String userName, String password, int sessionMode) {
+        throw new JMSRuntimeException(SQSMessagingClientConstants.UNSUPPORTED_METHOD);
+    }
+
+    @Override
+    public JMSContext createContext(int sessionMode) {
+        throw new JMSRuntimeException(SQSMessagingClientConstants.UNSUPPORTED_METHOD);
+    }
+}

--- a/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClient.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClient.java
@@ -1,0 +1,37 @@
+package com.amazon.sqs.javamessaging;
+
+import jakarta.jms.JMSException;
+import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+public interface AmazonSQSMessagingClient {
+
+    AwsClient getAmazonSQSClient();
+
+    void deleteMessage(DeleteMessageRequest deleteMessageRequest) throws JMSException;
+
+    DeleteMessageBatchResponse deleteMessageBatch(DeleteMessageBatchRequest deleteMessageBatchRequest) throws JMSException;
+
+    SendMessageResponse sendMessage(SendMessageRequest sendMessageRequest) throws JMSException;
+
+    boolean queueExists(String queueName) throws JMSException;
+
+    boolean queueExists(String queueName, String queueOwnerAccountId) throws JMSException;
+
+    GetQueueUrlResponse getQueueUrl(String queueName) throws JMSException;
+
+    GetQueueUrlResponse getQueueUrl(String queueName, String queueOwnerAccountId) throws JMSException;
+
+    GetQueueUrlResponse getQueueUrl(GetQueueUrlRequest getQueueUrlRequest) throws JMSException;
+
+    CreateQueueResponse createQueue(String queueName) throws JMSException;
+
+    CreateQueueResponse createQueue(CreateQueueRequest createQueueRequest) throws JMSException;
+
+    ReceiveMessageResponse receiveMessage(ReceiveMessageRequest receiveMessageRequest) throws JMSException;
+
+    void changeMessageVisibility(ChangeMessageVisibilityRequest changeMessageVisibilityRequest) throws JMSException;
+
+    ChangeMessageVisibilityBatchResponse changeMessageVisibilityBatch(
+            ChangeMessageVisibilityBatchRequest changeMessageVisibilityBatchRequest) throws JMSException;
+}

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSAsyncConnectionFactory.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSAsyncConnectionFactory.java
@@ -1,17 +1,3 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- */
 package com.amazon.sqs.javamessaging;
 
 import jakarta.jms.JMSException;
@@ -20,56 +6,37 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.services.sqs.SqsClient;
-import software.amazon.awssdk.services.sqs.SqsClientBuilder;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+import software.amazon.awssdk.services.sqs.SqsAsyncClientBuilder;
 
 import java.util.function.Supplier;
 
-/**
- * A ConnectionFactory object encapsulates a set of connection configuration
- * parameters for <code>SqsClient</code> as well as setting
- * <code>numberOfMessagesToPrefetch</code>.
- * <p>
- * The <code>numberOfMessagesToPrefetch</code> parameter is used to size of the
- * prefetched messages, which can be tuned based on the application workload. It
- * helps in returning messages from internal buffers(if there is any) instead of
- * waiting for the SQS <code>receiveMessage</code> call to return.
- * <p>
- * If more physical connections than the default maximum value (that is 50 as of
- * today) are needed on the connection pool,
- * {@link software.amazon.awssdk.core.client.config.ClientOverrideConfiguration} needs to be configured.
- * <p>
- * None of the <code>createConnection</code> methods set-up the physical
- * connection to SQS, so validity of credentials are not checked with those
- * methods.
- */
-
-public class SQSConnectionFactory extends AbstractSQSConnectionFactory {
+public class SQSAsyncConnectionFactory extends AbstractSQSConnectionFactory {
     private final ProviderConfiguration providerConfiguration;
-    private final Supplier<SqsClient> amazonSQSClientSupplier;
+    private final Supplier<SqsAsyncClient> amazonSQSClientSupplier;
 
     /**
      * Creates a SQSConnectionFactory that uses default ProviderConfiguration
-     * and SqsClientBuilder.standard() for creating SqsClient connections.
-     * Every SQSConnection will have its own copy of SqsClient.
+     * and SqsClientAsyncBuilder.standard() for creating SqsAsyncClient connections.
+     * Every SQSConnection will have its own copy of SqsAsyncClient.
      */
-    public SQSConnectionFactory() {
+    public SQSAsyncConnectionFactory() {
         this(new ProviderConfiguration());
     }
 
     /**
-     * Creates a SQSConnectionFactory that uses SqsClientBuilder.standard() for creating SqsClient connections.
-     * Every SQSConnection will have its own copy of SqsClient.
+     * Creates a SQSConnectionFactory that uses SqsAsyncClientBuilder.standard() for creating SqsAsyncClient connections.
+     * Every SQSConnection will have its own copy of SqsAsyncClient.
      */
-    public SQSConnectionFactory(ProviderConfiguration providerConfiguration) {
-        this(providerConfiguration, SqsClient.create());
+    public SQSAsyncConnectionFactory(ProviderConfiguration providerConfiguration) {
+        this(providerConfiguration, SqsAsyncClient.create());
     }
 
     /**
-     * Creates a SQSConnectionFactory that uses the provided SqsClient connection.
-     * Every SQSConnection will use the same provided SqsClient.
+     * Creates a SQSConnectionFactory that uses the provided SqsAsyncClient connection.
+     * Every SQSConnection will use the same provided SqsAsyncClient.
      */
-    public SQSConnectionFactory(ProviderConfiguration providerConfiguration, final SqsClient client) {
+    public SQSAsyncConnectionFactory(ProviderConfiguration providerConfiguration, final SqsAsyncClient client) {
         if (providerConfiguration == null) {
             throw new IllegalArgumentException("Provider configuration cannot be null");
         }
@@ -84,7 +51,7 @@ public class SQSConnectionFactory extends AbstractSQSConnectionFactory {
      * Creates a SQSConnectionFactory that uses the provided SqsClientBuilder for creating AmazonSQS client connections.
      * Every SQSConnection will have its own copy of AmazonSQS client created through the provided builder.
      */
-    public SQSConnectionFactory(ProviderConfiguration providerConfiguration, final SqsClientBuilder clientBuilder) {
+    public SQSAsyncConnectionFactory(ProviderConfiguration providerConfiguration, final SqsAsyncClientBuilder clientBuilder) {
         if (providerConfiguration == null) {
             throw new IllegalArgumentException("Provider configuration cannot be null");
         }
@@ -99,7 +66,7 @@ public class SQSConnectionFactory extends AbstractSQSConnectionFactory {
     @Override
     public SQSConnection createConnection() throws JMSException {
         try {
-            SqsClient amazonSQS = amazonSQSClientSupplier.get();
+            SqsAsyncClient amazonSQS = amazonSQSClientSupplier.get();
             return createConnection(amazonSQS, null);
         } catch (RuntimeException e) {
             throw (JMSException) new JMSException("Error creating SQS client: " + e.getMessage()).initCause(e);
@@ -119,15 +86,15 @@ public class SQSConnectionFactory extends AbstractSQSConnectionFactory {
 
     public SQSConnection createConnection(AwsCredentialsProvider awsCredentialsProvider) throws JMSException {
         try {
-            SqsClient amazonSQS = amazonSQSClientSupplier.get();
+            SqsAsyncClient amazonSQS = amazonSQSClientSupplier.get();
             return createConnection(amazonSQS, awsCredentialsProvider);
         } catch (Exception e) {
             throw (JMSException) new JMSException("Error creating SQS client: " + e.getMessage()).initCause(e);
         }
     }
 
-    private SQSConnection createConnection(SqsClient amazonSQS, AwsCredentialsProvider awsCredentialsProvider) throws JMSException {
-        AmazonSQSMessagingClientWrapper amazonSQSClientJMSWrapper = new AmazonSQSMessagingClientWrapper(amazonSQS, awsCredentialsProvider);
+    private SQSConnection createConnection(SqsAsyncClient amazonSQS, AwsCredentialsProvider awsCredentialsProvider) throws JMSException {
+        AmazonSQSAsyncMessagingClientWrapper amazonSQSClientJMSWrapper = new AmazonSQSAsyncMessagingClientWrapper(amazonSQS, awsCredentialsProvider);
         return new SQSConnection(amazonSQSClientJMSWrapper, providerConfiguration.getNumberOfMessagesToPrefetch());
     }
 

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSConnection.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSConnection.java
@@ -31,7 +31,7 @@ import jakarta.jms.Session;
 import jakarta.jms.Topic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.awscore.AwsClient;
 
 import java.util.Collections;
 import java.util.Set;
@@ -84,7 +84,7 @@ public class SQSConnection implements Connection, QueueConnection {
     /** Used for interactions with connection state. */
     private final Object stateLock = new Object();
     
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
 
     /**
      * Configures the amount of messages that can be prefetched by a consumer. A
@@ -106,7 +106,7 @@ public class SQSConnection implements Connection, QueueConnection {
 
     private final Set<Session> sessions = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-    SQSConnection(AmazonSQSMessagingClientWrapper amazonSQSClientJMSWrapper, int numberOfMessagesToPrefetch) {
+    SQSConnection(AmazonSQSMessagingClient amazonSQSClientJMSWrapper, int numberOfMessagesToPrefetch) {
         amazonSQSClient = amazonSQSClientJMSWrapper;
         this.numberOfMessagesToPrefetch = numberOfMessagesToPrefetch;
 
@@ -116,9 +116,9 @@ public class SQSConnection implements Connection, QueueConnection {
      * Get the AmazonSQSClient used by this connection. This can be used to do administrative operations
      * that aren't included in the JMS specification, e.g. creating new queues.
      * 
-     * @return the SqsClient used by this connection
+     * @return the AwsClient used by this connection
      */
-    public SqsClient getAmazonSQSClient() {
+    public AwsClient getAmazonSQSClient() {
         return amazonSQSClient.getAmazonSQSClient();
     }
 
@@ -130,7 +130,7 @@ public class SQSConnection implements Connection, QueueConnection {
      * 
      * @return  wrapped version of the AmazonSQSClient used by this connection
      */
-    public AmazonSQSMessagingClientWrapper getWrappedAmazonSQSClient() {
+    public AmazonSQSMessagingClient getWrappedAmazonSQSClient() {
         return amazonSQSClient;        
     }
     

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
@@ -63,7 +63,7 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
 
     protected static final String ALL = "All";
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
 
     private final String queueUrl;
 
@@ -124,7 +124,7 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
 
     SQSMessageConsumerPrefetch(SQSSessionCallbackScheduler sqsSessionRunnable, Acknowledger acknowledger,
                                NegativeAcknowledger negativeAcknowledger, SQSQueueDestination sqsDestination,
-                               AmazonSQSMessagingClientWrapper amazonSQSClient, int numberOfMessagesToPrefetch) {
+                               AmazonSQSMessagingClient amazonSQSClient, int numberOfMessagesToPrefetch) {
         this.amazonSQSClient = amazonSQSClient;
         this.numberOfMessagesToPrefetch = numberOfMessagesToPrefetch;
 

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageProducer.java
@@ -86,11 +86,11 @@ public class SQSMessageProducer implements MessageProducer, QueueSender {
      */
     final AtomicBoolean closed = new AtomicBoolean(false);
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
     private final SQSQueueDestination sqsDestination;
     private final SQSSession parentSQSSession;
 
-    SQSMessageProducer(AmazonSQSMessagingClientWrapper amazonSQSClient, SQSSession parentSQSSession,
+    SQSMessageProducer(AmazonSQSMessagingClient amazonSQSClient, SQSSession parentSQSSession,
                        SQSQueueDestination destination) throws JMSException {
         this.sqsDestination = destination;
         this.amazonSQSClient = amazonSQSClient;

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSSession.java
@@ -128,7 +128,7 @@ public class SQSSession implements Session, QueueSession {
      */
     private volatile boolean closing = false;
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
     private final SQSConnection parentSQSConnection;
 
     /**

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/AcknowledgeMode.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/AcknowledgeMode.java
@@ -14,7 +14,7 @@
  */
 package com.amazon.sqs.javamessaging.acknowledge;
 
-import com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper;
+import com.amazon.sqs.javamessaging.AmazonSQSMessagingClient;
 import com.amazon.sqs.javamessaging.SQSSession;
 
 /**
@@ -60,7 +60,7 @@ public enum AcknowledgeMode {
      * @param parentSQSSession
      *            the associated session for the acknowledger
      */
-    public Acknowledger createAcknowledger(AmazonSQSMessagingClientWrapper amazonSQSClient, SQSSession parentSQSSession) {
+    public Acknowledger createAcknowledger(AmazonSQSMessagingClient amazonSQSClient, SQSSession parentSQSSession) {
         return switch (this) {
             case ACK_AUTO -> new AutoAcknowledger(amazonSQSClient, parentSQSSession);
             case ACK_RANGE -> new RangedAcknowledger(amazonSQSClient, parentSQSSession);

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/AutoAcknowledger.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/AutoAcknowledger.java
@@ -14,7 +14,7 @@
  */
 package com.amazon.sqs.javamessaging.acknowledge;
 
-import com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper;
+import com.amazon.sqs.javamessaging.AmazonSQSMessagingClient;
 import com.amazon.sqs.javamessaging.SQSSession;
 import com.amazon.sqs.javamessaging.message.SQSMessage;
 import jakarta.jms.JMSException;
@@ -31,10 +31,10 @@ import java.util.List;
  */
 public class AutoAcknowledger implements Acknowledger {
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
     private final SQSSession session;
 
-    public AutoAcknowledger(AmazonSQSMessagingClientWrapper amazonSQSClient, SQSSession session) {
+    public AutoAcknowledger(AmazonSQSMessagingClient amazonSQSClient, SQSSession session) {
         this.amazonSQSClient = amazonSQSClient;
         this.session = session;
     }

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/NegativeAcknowledger.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/NegativeAcknowledger.java
@@ -14,7 +14,7 @@
  */
 package com.amazon.sqs.javamessaging.acknowledge;
 
-import com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper;
+import com.amazon.sqs.javamessaging.AmazonSQSMessagingClient;
 import com.amazon.sqs.javamessaging.SQSMessageConsumerPrefetch.MessageManager;
 import com.amazon.sqs.javamessaging.SQSMessagingClientConstants;
 import com.amazon.sqs.javamessaging.message.SQSMessage;
@@ -39,9 +39,9 @@ public class NegativeAcknowledger extends BulkSQSOperation {
 
     private static final int NACK_TIMEOUT = 0;
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
 
-    public NegativeAcknowledger(AmazonSQSMessagingClientWrapper amazonSQSClient) {
+    public NegativeAcknowledger(AmazonSQSMessagingClient amazonSQSClient) {
         this.amazonSQSClient = amazonSQSClient;
     }
     

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/RangedAcknowledger.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/RangedAcknowledger.java
@@ -14,7 +14,7 @@
  */
 package com.amazon.sqs.javamessaging.acknowledge;
 
-import com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper;
+import com.amazon.sqs.javamessaging.AmazonSQSMessagingClient;
 import com.amazon.sqs.javamessaging.SQSSession;
 import com.amazon.sqs.javamessaging.message.SQSMessage;
 import jakarta.jms.JMSException;
@@ -41,13 +41,13 @@ import java.util.Queue;
 public class RangedAcknowledger extends BulkSQSOperation implements Acknowledger {
     private static final Logger LOG = LoggerFactory.getLogger(RangedAcknowledger.class);
     
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
 
     private final SQSSession session;
     
     private final Queue<SQSMessageIdentifier> unAckMessages;
 
-    public RangedAcknowledger(AmazonSQSMessagingClientWrapper amazonSQSClient, SQSSession session) {
+    public RangedAcknowledger(AmazonSQSMessagingClient amazonSQSClient, SQSSession session) {
         this.amazonSQSClient = amazonSQSClient;
         this.session = session;
         this.unAckMessages  = new LinkedList<>();

--- a/src/main/java/com/amazon/sqs/javamessaging/acknowledge/UnorderedAcknowledger.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/acknowledge/UnorderedAcknowledger.java
@@ -14,7 +14,7 @@
  */
 package com.amazon.sqs.javamessaging.acknowledge;
 
-import com.amazon.sqs.javamessaging.AmazonSQSMessagingClientWrapper;
+import com.amazon.sqs.javamessaging.AmazonSQSMessagingClient;
 import com.amazon.sqs.javamessaging.SQSSession;
 import com.amazon.sqs.javamessaging.message.SQSMessage;
 import jakarta.jms.JMSException;
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 public class UnorderedAcknowledger implements Acknowledger {
 
-    private final AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private final AmazonSQSMessagingClient amazonSQSClient;
     
     private final SQSSession session;
     
@@ -40,7 +40,7 @@ public class UnorderedAcknowledger implements Acknowledger {
     // identifier
     private final Map<String, SQSMessageIdentifier> unAckMessages;
 
-    public UnorderedAcknowledger (AmazonSQSMessagingClientWrapper amazonSQSClient, SQSSession session) {
+    public UnorderedAcknowledger (AmazonSQSMessagingClient amazonSQSClient, SQSSession session) {
         this.amazonSQSClient = amazonSQSClient;
         this.session = session;
         this.unAckMessages  = new HashMap<>();

--- a/src/test/java/com/amazon/sqs/javamessaging/AcknowledgerCommon.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AcknowledgerCommon.java
@@ -35,7 +35,7 @@ public class AcknowledgerCommon {
 
     protected String baseQueueUrl = "queueUrl";
     protected Acknowledger acknowledger;
-    protected AmazonSQSMessagingClientWrapper amazonSQSClient;
+    protected AmazonSQSMessagingClient amazonSQSClient;
     protected List<SQSMessage> populatedMessages = new ArrayList<>();
 
     /*

--- a/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClientWrapperTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AmazonSQSMessagingClientWrapperTest.java
@@ -49,7 +49,7 @@ public class AmazonSQSMessagingClientWrapperTest {
     private static final String OWNER_ACCOUNT_ID = "accountId";
 
     private SqsClient amazonSQSClient;
-    private AmazonSQSMessagingClientWrapper wrapper;
+    private AmazonSQSMessagingClient wrapper;
 
     @BeforeEach
     public void setup() throws JMSException {

--- a/src/test/java/com/amazon/sqs/javamessaging/AutoAcknowledgerTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/AutoAcknowledgerTest.java
@@ -41,7 +41,7 @@ public class AutoAcknowledgerTest {
     private static final String RECEIPT_HANDLE = "ReceiptHandle";
 
     private AutoAcknowledger acknowledger;
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
     private SQSSession session;
 
     @BeforeEach

--- a/src/test/java/com/amazon/sqs/javamessaging/MessageListenerConcurrentOperationTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/MessageListenerConcurrentOperationTest.java
@@ -44,7 +44,7 @@ public class MessageListenerConcurrentOperationTest {
     private static final String QUEUE_NAME = "queueName";
     private static final int NUMBER_OF_MESSAGES_TO_PREFETCH = 10;
 
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
     private SQSMessageConsumerPrefetch.MessageManager msgManager;
     private volatile SQSSession session;
     private volatile SQSConnection connection;

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSConnectionTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSConnectionTest.java
@@ -58,7 +58,7 @@ public class SQSConnectionTest {
         destination = new SQSQueueDestination(QUEUE_NAME, QUEUE_URL);
 
         int numberOfMessagesToPrefetch = 10;
-        AmazonSQSMessagingClientWrapper amazonSQSClientJMSWrapper = mock(AmazonSQSMessagingClientWrapper.class);
+        AmazonSQSMessagingClient amazonSQSClientJMSWrapper = mock(AmazonSQSMessagingClientWrapper.class);
         sqsConnection = spy(new SQSConnection(amazonSQSClientJMSWrapper, numberOfMessagesToPrefetch));
 
         session1 = mock(SQSSession.class);

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchFifoTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchFifoTest.java
@@ -65,7 +65,7 @@ public class SQSMessageConsumerPrefetchFifoTest {
     private NegativeAcknowledger negativeAcknowledger;
     private SQSMessageConsumerPrefetch consumerPrefetch;
 
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
 
     /**
      * Test one full prefetch operation works as expected

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
@@ -91,7 +91,7 @@ public class SQSMessageConsumerPrefetchTest {
     private ExponentialBackoffStrategy backoffStrategy;
 
     private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
 
     /**
      * Test one full prefetch operation works as expected

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageProducerFifoTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageProducerFifoTest.java
@@ -62,7 +62,7 @@ public class SQSMessageProducerFifoTest {
 
     private SQSMessageProducer producer;
     private SQSQueueDestination destination;
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
     private Acknowledger acknowledger;
 
     @BeforeEach

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageProducerTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageProducerTest.java
@@ -72,7 +72,7 @@ public class SQSMessageProducerTest {
     private SQSMessageProducer producer;
     private SQSQueueDestination destination;
     private SQSSession sqsSession;
-    private AmazonSQSMessagingClientWrapper amazonSQSClient;
+    private AmazonSQSMessagingClient amazonSQSClient;
     private Acknowledger acknowledger;
 
     @BeforeEach

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSSessionTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSSessionTest.java
@@ -80,7 +80,7 @@ public class SQSSessionTest {
     private SQSMessageConsumer consumer2;
     private SQSMessageProducer producer1;
     private SQSMessageProducer producer2;
-    private AmazonSQSMessagingClientWrapper sqsClientJMSWrapper;
+    private AmazonSQSMessagingClient sqsClientJMSWrapper;
 
     @BeforeEach
     public void setup() throws JMSException {


### PR DESCRIPTION
*Issue #187 :*

*Description of changes:*
Add basic support of `SqsAsyncClient`:

1. Create `AmazonSQSMessagingClient` interface that is implemented by old `AmazonSQSMessagingClientWrapper` and new `AmazonSQSAsyncMessagingClientWrapper` classes. `AmazonSQSAsyncMessagingClientWrapper` is wrapper for `SqsAsyncClient`
2. Create `AbstractSQSConnectionFactory` abstract class that is used by old `SQSConnectionFactory` and new `SQSAsyncConnectionFactory` classes. `SQSAsyncConnectionFactory` create `SQSConnection` that uses `SqsAsyncClient`
3. Update all classes to use `AmazonSQSMessagingClient` interface 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
