### PR TITLE
Set JMSDeliveryTime to ApproximateFirstReceiveTimestamp

### DIFF
--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetch.java
@@ -382,12 +382,23 @@ public class SQSMessageConsumerPrefetch implements Runnable, PrefetchManager {
         }
 
         jmsMessage.setJMSTimestamp(getJMSTimestamp(message));
+        jmsMessage.setJMSDeliveryTime(getApproximateFirstReceiveTimestamp(message));
         return jmsMessage;
     }
 
     private long getJMSTimestamp(Message message) {
         Map<String, String> systemAttributes = message.attributesAsStrings();
         String timestamp = systemAttributes.get(SQSMessagingClientConstants.SENT_TIMESTAMP);
+        if (timestamp != null) {
+            return Long.parseLong(timestamp);
+        } else {
+            return 0L;
+        }
+    }
+
+    private long getApproximateFirstReceiveTimestamp(Message message) {
+        Map<String, String> systemAttributes = message.attributesAsStrings();
+        String timestamp = systemAttributes.get(SQSMessagingClientConstants.APPROXIMATE_FIRST_RECEIVE_TIMESTAMP);
         if (timestamp != null) {
             return Long.parseLong(timestamp);
         } else {

--- a/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/SQSMessagingClientConstants.java
@@ -80,6 +80,8 @@ public class SQSMessagingClientConstants {
 
     public static final String SEQUENCE_NUMBER = "SequenceNumber";
 
+    public static final String APPROXIMATE_FIRST_RECEIVE_TIMESTAMP = "ApproximateFirstReceiveTimestamp";
+
     static final String APPENDED_USER_AGENT_HEADER_VERSION;
     static {
         try {

--- a/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
+++ b/src/main/java/com/amazon/sqs/javamessaging/message/SQSMessage.java
@@ -104,6 +104,7 @@ public class SQSMessage implements Message {
     private String type;
     private SQSQueueDestination replyTo;
     private Destination destination;
+    private long deliveryTime;
 
     private final Map<String, JMSMessagePropertyValue> properties = new HashMap<>();
 
@@ -422,13 +423,12 @@ public class SQSMessage implements Message {
 
     @Override
     public long getJMSDeliveryTime() throws JMSException {
-        // FIXME
-        return 0;
+        return deliveryTime;
     }
 
     @Override
     public void setJMSDeliveryTime(long deliveryTime) throws JMSException {
-        // FIXME
+        this.deliveryTime = deliveryTime;
     }
 
     @Override

--- a/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
+++ b/src/test/java/com/amazon/sqs/javamessaging/SQSMessageConsumerPrefetchTest.java
@@ -997,7 +997,8 @@ public class SQSMessageConsumerPrefetchTest {
         long now = System.currentTimeMillis();
         Map<String, String> mapAttributes = Map.of(
                 SQSMessagingClientConstants.APPROXIMATE_RECEIVE_COUNT, "1",
-                SQSMessagingClientConstants.SENT_TIMESTAMP, Long.toString(now));
+                SQSMessagingClientConstants.SENT_TIMESTAMP, Long.toString(now),
+                SQSMessagingClientConstants.APPROXIMATE_FIRST_RECEIVE_TIMESTAMP, Long.toString(now));
 
         // Return message attributes with message type 'TEXT'
         Message message = Message.builder()
@@ -1017,6 +1018,7 @@ public class SQSMessageConsumerPrefetchTest {
         assertTrue(jsmMessage instanceof SQSTextMessage);
         assertEquals(message.body(), "MessageBody");
         assertEquals(jsmMessage.getJMSTimestamp(), now);
+        assertEquals(jsmMessage.getJMSDeliveryTime(), now);
     }
 
     /**
@@ -1830,7 +1832,7 @@ public class SQSMessageConsumerPrefetchTest {
 
         // Wait to make sure the received calls have gotten far enough to
         // wait on the message queue
-        allReceivesWaiting.await();
+        allReceivesWaiting.await(1000, TimeUnit.MILLISECONDS);
 
         assertEquals(concurrentReceives, consumerPrefetch.messagesRequested);
 


### PR DESCRIPTION
*Description of changes:*

Finishes a FIXME that will set `JMSDeliveryTime` to `ApproximateFirstReceiveTimestamp`.

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html 

_ApproximateFirstReceiveTimestamp – Returns the time the message was first received from the queue ([epoch time](http://en.wikipedia.org/wiki/Unix_time) in milliseconds)._


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
