### PR TITLE
Upgrade AWS SDK to 2.34.0 to resolve CVE-2025-24970

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
         </developer>
     </developers>
     <properties>
-        <aws-java-sdk.version>2.29.24</aws-java-sdk.version>
+        <aws-java-sdk.version>2.34.0</aws-java-sdk.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>


### PR DESCRIPTION
## Summary
Resolves CVE-2025-24970 by upgrading the AWS SDK for Java from `2.29.24` to `2.34.0`.

The vulnerable `io.netty:netty-handler:4.1.115.Final` is pulled in transitively through the SQS client's `software.amazon.awssdk:netty-nio-client`. CVE-2025-24970 (Netty `SslHandler` denial-of-service via a crafted SSL packet) is fixed in `netty-handler` `4.1.118.Final`.

Bumping the SDK to `2.34.0` advances the bundled Netty to `4.1.126.Final`, which is past the fix line.

**Before** (`mvn dependency:tree`):
```
software.amazon.awssdk:sqs:jar:2.29.24
\- software.amazon.awssdk:netty-nio-client:jar:2.29.24:runtime
   +- io.netty:netty-handler:jar:4.1.115.Final:runtime   <-- vulnerable
```

**After:**
```
software.amazon.awssdk:sqs:jar:2.34.0
\- software.amazon.awssdk:netty-nio-client:jar:2.34.0:runtime
   +- io.netty:netty-handler:jar:4.1.126.Final:runtime   <-- patched
```

## Change
One-line change to the `aws-java-sdk.version` property in `pom.xml`.

## Testing
`mvn clean install` (JDK 17) — all 517 existing unit tests pass against the upgraded SDK.

## Issues
Resolves #256
Resolves #261
